### PR TITLE
performance enhancements for image fetching

### DIFF
--- a/ui/src/components/CollectionPage.js
+++ b/ui/src/components/CollectionPage.js
@@ -33,7 +33,7 @@ const Cell = (props) => {
                 navigate(`/play/${item.id}`)
             }}
                 >
-                    <img src={ item.basic_information.thumb }
+                    <img src={ item.basic_information.cover_image }
                         alt={ item.basic_information.title }
                         width="175" height="175" />
                 </Box>
@@ -69,9 +69,6 @@ export default function CollectionPage() {
         var tmpArr = [];
         for(let i = 0; i < 10; i++) {
                let release = col.data["releases"][i];
-               let imgRes = await getDiscogsReleaseImage(release.id, username)
-               release.imgURL = imgRes.data;
-               console.log(release.imgURL)
                tmpArr.push(release)
                setCollection(tmpArr);
         }

--- a/ui/src/components/PlayPage.js
+++ b/ui/src/components/PlayPage.js
@@ -13,7 +13,6 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 
-
 const handleDelete = () => {
     console.log("delete was clicked");
 }
@@ -23,33 +22,24 @@ const handleClick = () => {
 }
 
 const TracklistTable = (props) => {
-    
-    //props will go here
-    //onclick to change to the play page with the album info
     const {tracks} = props
-
-    console.log("TRACKS", tracks)
     
     return (
     <TableContainer component={Paper} sx={{ maxHeight: 500 }}>
       <Table sticky-header sx={{ minWidth: 650 }} size="small" aria-label="sticky table">
         <TableHead>
-                <TableRow></TableRow>
+            <TableRow></TableRow>
         </TableHead>
         <TableBody>
-          {
-          tracks.map((track) => (
+          {tracks.map((track) => (
             <TableRow
               key={track.title}
               sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
             >
-              <TableCell>
-                { track.title }
-              </TableCell>
+              <TableCell>{ track.title }</TableCell>
               <TableCell align="right">{ track.duration || "XX:XX" }</TableCell>
             </TableRow>
-          ))
-          }
+          ))}
         </TableBody>
 
       </Table>
@@ -305,7 +295,7 @@ export default function PlayPage() {
                             boxShadow: 8,
                                 border: 1
                             }}>
-                                <img src={ releaseImg || "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png"}
+                                <img src={ releaseImg || release.thumb || "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/600px-No_image_available.svg.png"}
                                     alt={ release.title}
                                 width="175" height="175" />
                             </Box>


### PR DESCRIPTION
authenticated collection requests provide image URL within resposne, no need to make seperate calls for them in collection view. still need it on play page since the only image provided in release response is the low-res thumbnail version.